### PR TITLE
feat: デフォルトテーマをblueに変更

### DIFF
--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -19,7 +19,7 @@ export interface ThemeProviderProps {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
-  defaultTheme = 'light',
+  defaultTheme = 'blue',
   storageKey = 'modern-gui-theme'
 }) => {
   const availableThemes: ThemeName[] = ['light', 'dark', 'blue', 'green', 'purple', 'orange'];


### PR DESCRIPTION
## 概要
ThemeProviderのデフォルトテーマを`light`から`blue`に変更しました。

## 変更内容
- `src/theme/ThemeProvider.tsx`の`defaultTheme`パラメータを`'light'`から`'blue'`に変更
- よりモダンで洗練された印象を提供

## テスト確認
- [x] ESLint: 通過
- [x] TypeScript型チェック: 通過
- [x] 既存の機能に影響なし
- [x] テーマシステムの互換性維持

## 影響範囲
- 新規ユーザーがライブラリを使用する際のデフォルトテーマが変更される
- 既存のLocalStorage設定は保持されるため、既存ユーザーには影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)